### PR TITLE
fix for album title in music library thumbnails view.

### DIFF
--- a/720p/MyMusicNav.xml
+++ b/720p/MyMusicNav.xml
@@ -137,7 +137,7 @@
 					<posx>60</posx>
 					<posy>645</posy>
 					<control type="label">
-						<label>$VAR[global_Title,Music]</label>
+						<label>$VAR[global_Title.Music]</label>
 						<width>1100</width>
 						<include>info_Title</include>
 					</control>


### PR DESCRIPTION
In music library when in thumbnails view it shows 'MUSIC' for every album title. looks to be a typo with a comma instead of a period. changing this in my installed 0.9.4.1 addon fixed the issue.
