### PR TITLE
Change weather icon to show current conditions

### DIFF
--- a/720p/Variables.xml
+++ b/720p/Variables.xml
@@ -159,7 +159,7 @@
 	<variable name="toast_Icon">
 		<value condition="IntegerGreaterThan(Player.Volume,0) + [Window.IsActive(PVR) | Window.IsActive(Home)] + Skin.HasSetting(overlay.pvr) + PVR.HasNonRecordingTimer">DefaultTimer.png</value>
 		<value condition="IntegerGreaterThan(Player.Volume,0) + [Window.IsActive(PVR) | Window.IsActive(Home)] + Skin.HasSetting(overlay.pvr) + PVR.IsRecording">$INFO[PVR.NowRecordingChannelIcon]</value>
-		<value condition="IntegerGreaterThan(Player.Volume,0) + Weather.IsFetched">$INFO[Window(weather).Property(Day0.FanartCode),weather/small/,.png]</value>
+		<value condition="IntegerGreaterThan(Player.Volume,0) + Weather.IsFetched">$INFO[Window(weather).Property(Current.FanartCode),weather/small/,.png]</value>
 		<value>weather/small/na.png</value>
 	</variable>
 


### PR DESCRIPTION
The weather icon in the clock is displaying the next day's forecast, not the current conditions. IMO it's more useful for it to show current conditions.
