### PR TITLE
Fix fanart always displaying over visualizations

### DIFF
--- a/720p/MusicVisualisation.xml
+++ b/720p/MusicVisualisation.xml
@@ -15,7 +15,7 @@
 				<texture>$VAR[player:Fanart]</texture>
 				<aspectratio align="center" aligny="top">scale</aspectratio>
 				<animation effect="fade" end="60" time="0" condition="Skin.HasSetting(fanart.visualization.blend)">Conditional</animation>
-	
+				<visible>Skin.HasSetting(fanart.visualization) + Skin.HasSetting(artistslideshow.disable)</visible>
 			</control>
 			<control type="multiimage">
 				<include>screen_Dimensions</include>


### PR DESCRIPTION
This line got removed in 422a7cdd438936c64b50b6e489c4253dab64fb6b but without it, fanart always displays over visualizations even when that option is not selected.