### PR TITLE
Correct Finnish translation for "min"

### DIFF
--- a/language/Finnish/strings.po
+++ b/language/Finnish/strings.po
@@ -606,7 +606,7 @@ msgstr "Ohjelmavarastot"
 
 msgctxt "#31701"
 msgid "Min"
-msgstr "Matalin"
+msgstr "Min"
 
 msgctxt "#31702"
 msgid "Last played on"


### PR DESCRIPTION
"Min" has a double meaning in Finnish. It used to be translated as "Matalin" which actually means "lowest", often referred as "min" (in min-max). Yet in the UI I believe this is only used in Media information section to indicate the duration of a video. So it's actually used as a shortcut for "minutes" and as such should be translated as "min".